### PR TITLE
Fix login failures; fix Chrome warnings

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -33,8 +33,7 @@
   ],
   "minimum_chrome_version": "93",
   "background": {
-    "service_worker": "build/service_worker.js",
-    "scripts": ["build/service_worker.js"]
+    "service_worker": "build/service_worker.js"
   },
 
   "icons": {

--- a/extension/src/contentScript.ts
+++ b/extension/src/contentScript.ts
@@ -29,9 +29,7 @@ function listenToInput(input: HTMLInputElement): {
   const isLoggedIn =
     userInfo &&
     userInfo.id &&
-    userInfo.token &&
-    loggedInUser &&
-    loggedInUser.id === userInfo.id;
+    userInfo.token;
 
   const updateTokensForInput = throttle(
     () => {

--- a/extension/src/createTokenTag.tsx
+++ b/extension/src/createTokenTag.tsx
@@ -112,6 +112,12 @@ export default function createTokenTag(
             chrome.runtime.sendMessage(
               { data: "login", githubInfo },
               (success) => {
+                if (chrome.runtime.lastError) {
+                  console.error("Login message error:", chrome.runtime.lastError.message);
+                  alert("Failed to login. The extension may need to be reloaded.");
+                  sendEvent("action", "login", "fail", "inline");
+                  return;
+                }
                 if (success) {
                   function reload() {
                     window.location.reload();

--- a/extension/src/shared/auth/getLoggedInUser.ts
+++ b/extension/src/shared/auth/getLoggedInUser.ts
@@ -1,31 +1,35 @@
 export default function getLoggedInUser() {
-  const avatarNode = document.querySelector("img.avatar");
   let userName: string | null = "";
   let avatarUrl: string | null = "";
-  if (avatarNode) {
-    userName = (avatarNode.getAttribute("alt") || "").substring(1);
-    avatarUrl = avatarNode.getAttribute("src");
+
+  // Check the meta tag first — it's the most reliable source for the
+  // logged-in user and won't accidentally match another user's avatar.
+  const userNameMetaNode = document.head.querySelector(
+    'meta[name="user-login"]'
+  );
+
+  if (userNameMetaNode) {
+    userName = userNameMetaNode.getAttribute("content");
   }
 
   if (!userName) {
-    // The user name is hidden in a side panel, it's not in the alt of the profile
-    // picture any more, which is just bad accessibility. Boo Github devs!
+    const userNameNode = document.querySelector(
+      "[data-target='deferred-side-panel.panel'] .AppHeader-logo + div span.Truncate-text"
+    ) as HTMLSpanElement;
+    if (userNameNode) {
+      userName = userNameNode.textContent
+        ? userNameNode.textContent.trim()
+        : null;
+    }
+  }
 
-    const userNameMetaNode = document.head.querySelector(
-      'meta[name="user-login"]'
+  // Try to get the avatar URL from the logged-in user's avatar image
+  if (userName) {
+    const avatarNode = document.querySelector(
+      `img.avatar[alt="@${userName}"]`
     );
-
-    if (userNameMetaNode) {
-      userName = userNameMetaNode.getAttribute("content");
-    } else {
-      const userNameNode = document.querySelector(
-        "[data-target='deferred-side-panel.panel'] .AppHeader-logo + div span.Truncate-text"
-      ) as HTMLSpanElement;
-      if (userNameNode) {
-        userName = userNameNode.textContent
-          ? userNameNode.textContent.trim()
-          : null;
-      }
+    if (avatarNode) {
+      avatarUrl = avatarNode.getAttribute("src");
     }
   }
 

--- a/extension/src/shared/auth/getToken.ts
+++ b/extension/src/shared/auth/getToken.ts
@@ -35,31 +35,34 @@ export function getTokenHeadless(
       encodeURIComponent(redirectUri),
   };
 
-  if (!githubInfo.token || !githubInfo.id || !githubInfo.avatar) {
-    console.log("calling launchWebAuthFlow with options", options);
-
-    chrome.identity.launchWebAuthFlow(options, function (redirectUri2: string) {
-      console.log("launchWebAuthFlow callback with redirect ", redirectUri2);
-      if (chrome.runtime.lastError) {
-        console.error("launchWebAuthFlow error", chrome.runtime.lastError);
-        callback(new Error(chrome.runtime.lastError));
-        return;
-      }
-
-      // Upon success the response is appended to redirectUri, e.g.
-      // https://{app_id}.chromiumapp.org/provider_cb#access_token={value}
-      //     &refresh_token={value}
-      const matches = redirectUri2.match(redirectRe);
-
-      console.log("matches = ", matches);
-      if (matches && matches.length > 1) {
-        console.log("calling handleProviderResponse");
-        handleProviderResponse(parseRedirectFragment(matches[1]));
-      } else {
-        callback("Invalid redirect URI");
-      }
-    });
+  if (githubInfo.token && githubInfo.id && githubInfo.avatar) {
+    callback(null, githubInfo);
+    return;
   }
+
+  console.log("calling launchWebAuthFlow with options", options);
+
+  chrome.identity.launchWebAuthFlow(options, function (redirectUri2: string) {
+    console.log("launchWebAuthFlow callback with redirect ", redirectUri2);
+    if (chrome.runtime.lastError) {
+      console.error("launchWebAuthFlow error", chrome.runtime.lastError);
+      callback(new Error(chrome.runtime.lastError));
+      return;
+    }
+
+    // Upon success the response is appended to redirectUri, e.g.
+    // https://{app_id}.chromiumapp.org/provider_cb#access_token={value}
+    //     &refresh_token={value}
+    const matches = redirectUri2.match(redirectRe);
+
+    console.log("matches = ", matches);
+    if (matches && matches.length > 1) {
+      console.log("calling handleProviderResponse");
+      handleProviderResponse(parseRedirectFragment(matches[1]));
+    } else {
+      callback("Invalid redirect URI");
+    }
+  });
 
   function parseRedirectFragment(fragment: string) {
     const pairs = fragment.split(/&/);

--- a/extension/src/shared/auth/githubInfo.ts
+++ b/extension/src/shared/auth/githubInfo.ts
@@ -16,10 +16,13 @@ export async function getGithubInfo(): Promise<GithubInfo> {
       ["github_token", "github_id", "github_avatar"],
       function (results: any) {
         if (results.github_token) {
+          // Fall back to DOM for id/avatar if they weren't stored (e.g. from
+          // a prior broken OAuth flow that stored the token but not the user info).
+          const loggedInUser = getLoggedInUser();
           resolve({
             token: results.github_token || null,
-            id: results.github_id || null,
-            avatar: results.github_avatar || null,
+            id: results.github_id || (loggedInUser ? loggedInUser.id : null),
+            avatar: results.github_avatar || (loggedInUser ? loggedInUser.avatar : null),
             context: getGithubContext(),
           });
         } else {

--- a/popup/src/shared/auth/getLoggedInUser.ts
+++ b/popup/src/shared/auth/getLoggedInUser.ts
@@ -1,31 +1,35 @@
 export default function getLoggedInUser() {
-  const avatarNode = document.querySelector("img.avatar");
   let userName: string | null = "";
   let avatarUrl: string | null = "";
-  if (avatarNode) {
-    userName = (avatarNode.getAttribute("alt") || "").substring(1);
-    avatarUrl = avatarNode.getAttribute("src");
+
+  // Check the meta tag first — it's the most reliable source for the
+  // logged-in user and won't accidentally match another user's avatar.
+  const userNameMetaNode = document.head.querySelector(
+    'meta[name="user-login"]'
+  );
+
+  if (userNameMetaNode) {
+    userName = userNameMetaNode.getAttribute("content");
   }
 
   if (!userName) {
-    // The user name is hidden in a side panel, it's not in the alt of the profile
-    // picture any more, which is just bad accessibility. Boo Github devs!
+    const userNameNode = document.querySelector(
+      "[data-target='deferred-side-panel.panel'] .AppHeader-logo + div span.Truncate-text"
+    ) as HTMLSpanElement;
+    if (userNameNode) {
+      userName = userNameNode.textContent
+        ? userNameNode.textContent.trim()
+        : null;
+    }
+  }
 
-    const userNameMetaNode = document.head.querySelector(
-      'meta[name="user-login"]'
+  // Try to get the avatar URL from the logged-in user's avatar image
+  if (userName) {
+    const avatarNode = document.querySelector(
+      `img.avatar[alt="@${userName}"]`
     );
-
-    if (userNameMetaNode) {
-      userName = userNameMetaNode.getAttribute("content");
-    } else {
-      const userNameNode = document.querySelector(
-        "[data-target='deferred-side-panel.panel'] .AppHeader-logo + div span.Truncate-text"
-      ) as HTMLSpanElement;
-      if (userNameNode) {
-        userName = userNameNode.textContent
-          ? userNameNode.textContent.trim()
-          : null;
-      }
+    if (avatarNode) {
+      avatarUrl = avatarNode.getAttribute("src");
     }
   }
 

--- a/popup/src/shared/auth/getToken.ts
+++ b/popup/src/shared/auth/getToken.ts
@@ -35,31 +35,34 @@ export function getTokenHeadless(
       encodeURIComponent(redirectUri),
   };
 
-  if (!githubInfo.token || !githubInfo.id || !githubInfo.avatar) {
-    console.log("calling launchWebAuthFlow with options", options);
-
-    chrome.identity.launchWebAuthFlow(options, function (redirectUri2: string) {
-      console.log("launchWebAuthFlow callback with redirect ", redirectUri2);
-      if (chrome.runtime.lastError) {
-        console.error("launchWebAuthFlow error", chrome.runtime.lastError);
-        callback(new Error(chrome.runtime.lastError));
-        return;
-      }
-
-      // Upon success the response is appended to redirectUri, e.g.
-      // https://{app_id}.chromiumapp.org/provider_cb#access_token={value}
-      //     &refresh_token={value}
-      const matches = redirectUri2.match(redirectRe);
-
-      console.log("matches = ", matches);
-      if (matches && matches.length > 1) {
-        console.log("calling handleProviderResponse");
-        handleProviderResponse(parseRedirectFragment(matches[1]));
-      } else {
-        callback("Invalid redirect URI");
-      }
-    });
+  if (githubInfo.token && githubInfo.id && githubInfo.avatar) {
+    callback(null, githubInfo);
+    return;
   }
+
+  console.log("calling launchWebAuthFlow with options", options);
+
+  chrome.identity.launchWebAuthFlow(options, function (redirectUri2: string) {
+    console.log("launchWebAuthFlow callback with redirect ", redirectUri2);
+    if (chrome.runtime.lastError) {
+      console.error("launchWebAuthFlow error", chrome.runtime.lastError);
+      callback(new Error(chrome.runtime.lastError));
+      return;
+    }
+
+    // Upon success the response is appended to redirectUri, e.g.
+    // https://{app_id}.chromiumapp.org/provider_cb#access_token={value}
+    //     &refresh_token={value}
+    const matches = redirectUri2.match(redirectRe);
+
+    console.log("matches = ", matches);
+    if (matches && matches.length > 1) {
+      console.log("calling handleProviderResponse");
+      handleProviderResponse(parseRedirectFragment(matches[1]));
+    } else {
+      callback("Invalid redirect URI");
+    }
+  });
 
   function parseRedirectFragment(fragment: string) {
     const pairs = fragment.split(/&/);

--- a/popup/src/shared/auth/githubInfo.ts
+++ b/popup/src/shared/auth/githubInfo.ts
@@ -16,10 +16,13 @@ export async function getGithubInfo(): Promise<GithubInfo> {
       ["github_token", "github_id", "github_avatar"],
       function (results: any) {
         if (results.github_token) {
+          // Fall back to DOM for id/avatar if they weren't stored (e.g. from
+          // a prior broken OAuth flow that stored the token but not the user info).
+          const loggedInUser = getLoggedInUser();
           resolve({
             token: results.github_token || null,
-            id: results.github_id || null,
-            avatar: results.github_avatar || null,
+            id: results.github_id || (loggedInUser ? loggedInUser.id : null),
+            avatar: results.github_avatar || (loggedInUser ? loggedInUser.avatar : null),
             context: getGithubContext(),
           });
         } else {

--- a/shared/auth/getLoggedInUser.ts
+++ b/shared/auth/getLoggedInUser.ts
@@ -1,31 +1,35 @@
 export default function getLoggedInUser() {
-  const avatarNode = document.querySelector("img.avatar");
   let userName: string | null = "";
   let avatarUrl: string | null = "";
-  if (avatarNode) {
-    userName = (avatarNode.getAttribute("alt") || "").substring(1);
-    avatarUrl = avatarNode.getAttribute("src");
+
+  // Check the meta tag first — it's the most reliable source for the
+  // logged-in user and won't accidentally match another user's avatar.
+  const userNameMetaNode = document.head.querySelector(
+    'meta[name="user-login"]'
+  );
+
+  if (userNameMetaNode) {
+    userName = userNameMetaNode.getAttribute("content");
   }
 
   if (!userName) {
-    // The user name is hidden in a side panel, it's not in the alt of the profile
-    // picture any more, which is just bad accessibility. Boo Github devs!
+    const userNameNode = document.querySelector(
+      "[data-target='deferred-side-panel.panel'] .AppHeader-logo + div span.Truncate-text"
+    ) as HTMLSpanElement;
+    if (userNameNode) {
+      userName = userNameNode.textContent
+        ? userNameNode.textContent.trim()
+        : null;
+    }
+  }
 
-    const userNameMetaNode = document.head.querySelector(
-      'meta[name="user-login"]'
+  // Try to get the avatar URL from the logged-in user's avatar image
+  if (userName) {
+    const avatarNode = document.querySelector(
+      `img.avatar[alt="@${userName}"]`
     );
-
-    if (userNameMetaNode) {
-      userName = userNameMetaNode.getAttribute("content");
-    } else {
-      const userNameNode = document.querySelector(
-        "[data-target='deferred-side-panel.panel'] .AppHeader-logo + div span.Truncate-text"
-      ) as HTMLSpanElement;
-      if (userNameNode) {
-        userName = userNameNode.textContent
-          ? userNameNode.textContent.trim()
-          : null;
-      }
+    if (avatarNode) {
+      avatarUrl = avatarNode.getAttribute("src");
     }
   }
 

--- a/shared/auth/getToken.ts
+++ b/shared/auth/getToken.ts
@@ -35,31 +35,34 @@ export function getTokenHeadless(
       encodeURIComponent(redirectUri),
   };
 
-  if (!githubInfo.token || !githubInfo.id || !githubInfo.avatar) {
-    console.log("calling launchWebAuthFlow with options", options);
-
-    chrome.identity.launchWebAuthFlow(options, function (redirectUri2: string) {
-      console.log("launchWebAuthFlow callback with redirect ", redirectUri2);
-      if (chrome.runtime.lastError) {
-        console.error("launchWebAuthFlow error", chrome.runtime.lastError);
-        callback(new Error(chrome.runtime.lastError));
-        return;
-      }
-
-      // Upon success the response is appended to redirectUri, e.g.
-      // https://{app_id}.chromiumapp.org/provider_cb#access_token={value}
-      //     &refresh_token={value}
-      const matches = redirectUri2.match(redirectRe);
-
-      console.log("matches = ", matches);
-      if (matches && matches.length > 1) {
-        console.log("calling handleProviderResponse");
-        handleProviderResponse(parseRedirectFragment(matches[1]));
-      } else {
-        callback("Invalid redirect URI");
-      }
-    });
+  if (githubInfo.token && githubInfo.id && githubInfo.avatar) {
+    callback(null, githubInfo);
+    return;
   }
+
+  console.log("calling launchWebAuthFlow with options", options);
+
+  chrome.identity.launchWebAuthFlow(options, function (redirectUri2: string) {
+    console.log("launchWebAuthFlow callback with redirect ", redirectUri2);
+    if (chrome.runtime.lastError) {
+      console.error("launchWebAuthFlow error", chrome.runtime.lastError);
+      callback(new Error(chrome.runtime.lastError));
+      return;
+    }
+
+    // Upon success the response is appended to redirectUri, e.g.
+    // https://{app_id}.chromiumapp.org/provider_cb#access_token={value}
+    //     &refresh_token={value}
+    const matches = redirectUri2.match(redirectRe);
+
+    console.log("matches = ", matches);
+    if (matches && matches.length > 1) {
+      console.log("calling handleProviderResponse");
+      handleProviderResponse(parseRedirectFragment(matches[1]));
+    } else {
+      callback("Invalid redirect URI");
+    }
+  });
 
   function parseRedirectFragment(fragment: string) {
     const pairs = fragment.split(/&/);

--- a/shared/auth/githubInfo.ts
+++ b/shared/auth/githubInfo.ts
@@ -16,10 +16,13 @@ export async function getGithubInfo(): Promise<GithubInfo> {
       ["github_token", "github_id", "github_avatar"],
       function (results: any) {
         if (results.github_token) {
+          // Fall back to DOM for id/avatar if they weren't stored (e.g. from
+          // a prior broken OAuth flow that stored the token but not the user info).
+          const loggedInUser = getLoggedInUser();
           resolve({
             token: results.github_token || null,
-            id: results.github_id || null,
-            avatar: results.github_avatar || null,
+            id: results.github_id || (loggedInUser ? loggedInUser.id : null),
+            avatar: results.github_avatar || (loggedInUser ? loggedInUser.avatar : null),
             context: getGithubContext(),
           });
         } else {

--- a/site-nextjs/lib/shared/auth/getLoggedInUser.ts
+++ b/site-nextjs/lib/shared/auth/getLoggedInUser.ts
@@ -1,31 +1,35 @@
 export default function getLoggedInUser() {
-  const avatarNode = document.querySelector("img.avatar");
   let userName: string | null = "";
   let avatarUrl: string | null = "";
-  if (avatarNode) {
-    userName = (avatarNode.getAttribute("alt") || "").substring(1);
-    avatarUrl = avatarNode.getAttribute("src");
+
+  // Check the meta tag first — it's the most reliable source for the
+  // logged-in user and won't accidentally match another user's avatar.
+  const userNameMetaNode = document.head.querySelector(
+    'meta[name="user-login"]'
+  );
+
+  if (userNameMetaNode) {
+    userName = userNameMetaNode.getAttribute("content");
   }
 
   if (!userName) {
-    // The user name is hidden in a side panel, it's not in the alt of the profile
-    // picture any more, which is just bad accessibility. Boo Github devs!
+    const userNameNode = document.querySelector(
+      "[data-target='deferred-side-panel.panel'] .AppHeader-logo + div span.Truncate-text"
+    ) as HTMLSpanElement;
+    if (userNameNode) {
+      userName = userNameNode.textContent
+        ? userNameNode.textContent.trim()
+        : null;
+    }
+  }
 
-    const userNameMetaNode = document.head.querySelector(
-      'meta[name="user-login"]'
+  // Try to get the avatar URL from the logged-in user's avatar image
+  if (userName) {
+    const avatarNode = document.querySelector(
+      `img.avatar[alt="@${userName}"]`
     );
-
-    if (userNameMetaNode) {
-      userName = userNameMetaNode.getAttribute("content");
-    } else {
-      const userNameNode = document.querySelector(
-        "[data-target='deferred-side-panel.panel'] .AppHeader-logo + div span.Truncate-text"
-      ) as HTMLSpanElement;
-      if (userNameNode) {
-        userName = userNameNode.textContent
-          ? userNameNode.textContent.trim()
-          : null;
-      }
+    if (avatarNode) {
+      avatarUrl = avatarNode.getAttribute("src");
     }
   }
 

--- a/site-nextjs/lib/shared/auth/getToken.ts
+++ b/site-nextjs/lib/shared/auth/getToken.ts
@@ -35,31 +35,34 @@ export function getTokenHeadless(
       encodeURIComponent(redirectUri),
   };
 
-  if (!githubInfo.token || !githubInfo.id || !githubInfo.avatar) {
-    console.log("calling launchWebAuthFlow with options", options);
-
-    chrome.identity.launchWebAuthFlow(options, function (redirectUri2: string) {
-      console.log("launchWebAuthFlow callback with redirect ", redirectUri2);
-      if (chrome.runtime.lastError) {
-        console.error("launchWebAuthFlow error", chrome.runtime.lastError);
-        callback(new Error(chrome.runtime.lastError));
-        return;
-      }
-
-      // Upon success the response is appended to redirectUri, e.g.
-      // https://{app_id}.chromiumapp.org/provider_cb#access_token={value}
-      //     &refresh_token={value}
-      const matches = redirectUri2.match(redirectRe);
-
-      console.log("matches = ", matches);
-      if (matches && matches.length > 1) {
-        console.log("calling handleProviderResponse");
-        handleProviderResponse(parseRedirectFragment(matches[1]));
-      } else {
-        callback("Invalid redirect URI");
-      }
-    });
+  if (githubInfo.token && githubInfo.id && githubInfo.avatar) {
+    callback(null, githubInfo);
+    return;
   }
+
+  console.log("calling launchWebAuthFlow with options", options);
+
+  chrome.identity.launchWebAuthFlow(options, function (redirectUri2: string) {
+    console.log("launchWebAuthFlow callback with redirect ", redirectUri2);
+    if (chrome.runtime.lastError) {
+      console.error("launchWebAuthFlow error", chrome.runtime.lastError);
+      callback(new Error(chrome.runtime.lastError));
+      return;
+    }
+
+    // Upon success the response is appended to redirectUri, e.g.
+    // https://{app_id}.chromiumapp.org/provider_cb#access_token={value}
+    //     &refresh_token={value}
+    const matches = redirectUri2.match(redirectRe);
+
+    console.log("matches = ", matches);
+    if (matches && matches.length > 1) {
+      console.log("calling handleProviderResponse");
+      handleProviderResponse(parseRedirectFragment(matches[1]));
+    } else {
+      callback("Invalid redirect URI");
+    }
+  });
 
   function parseRedirectFragment(fragment: string) {
     const pairs = fragment.split(/&/);

--- a/site-nextjs/lib/shared/auth/githubInfo.ts
+++ b/site-nextjs/lib/shared/auth/githubInfo.ts
@@ -16,10 +16,13 @@ export async function getGithubInfo(): Promise<GithubInfo> {
       ["github_token", "github_id", "github_avatar"],
       function (results: any) {
         if (results.github_token) {
+          // Fall back to DOM for id/avatar if they weren't stored (e.g. from
+          // a prior broken OAuth flow that stored the token but not the user info).
+          const loggedInUser = getLoggedInUser();
           resolve({
             token: results.github_token || null,
-            id: results.github_id || null,
-            avatar: results.github_avatar || null,
+            id: results.github_id || (loggedInUser ? loggedInUser.id : null),
+            avatar: results.github_avatar || (loggedInUser ? loggedInUser.avatar : null),
             context: getGithubContext(),
           });
         } else {

--- a/site-nextjs/pages/api/oauth/[slug].ts
+++ b/site-nextjs/pages/api/oauth/[slug].ts
@@ -45,13 +45,14 @@ export default async function oauthApi(
       userInfo.avatar,
       extensionId
     );
+    return;
   } else if (code) {
     console.log(
       "Oauth got an access code ",
       code,
       " exchanging code for token"
     );
-    const token = await exchangeCodeForToken(code);
+    const token = await exchangeCodeForToken(code, extensionId);
     console.log("Exchanged code for the token: ", token);
 
     if (token) {
@@ -68,7 +69,7 @@ export default async function oauthApi(
   const idx = (req.url || "").indexOf("?");
   const queryString = (req.url || "").substring(idx + 1);
   res.redirect(
-    `https://${EXTENSION_ID}.chromiumapp.org/provider_cb?` + queryString
+    `https://${extensionId}.chromiumapp.org/provider_cb?` + queryString
   );
 }
 
@@ -132,8 +133,9 @@ function redirectWithToken(
   res.redirect(nextRedirectUrl);
 }
 
-async function exchangeCodeForToken(code: string): Promise<string> {
+async function exchangeCodeForToken(code: string, extensionId: string): Promise<string> {
   return new Promise(async (resolve, reject) => {
+    const redirectUri = `${thisRedirectUri}/${extensionId}`;
     const url =
       "https://github.com/login/oauth/access_token?" +
       "client_id=" +
@@ -141,7 +143,7 @@ async function exchangeCodeForToken(code: string): Promise<string> {
       "&client_secret=" +
       GITHUB_CLIENT_SECRET +
       "&redirect_uri=" +
-      encodeURIComponent(thisRedirectUri) +
+      encodeURIComponent(redirectUri) +
       "&code=" +
       code;
 


### PR DESCRIPTION
* The redirect flow was broken and logins failed. Claude noted the
  extensionID issue fixed in the server.
* The slash-command pop-up never knew when you were logged in. Also
  could fail to find the avatar. Both of these fixed extension side.
* Also, there was a warning about background scripts.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
